### PR TITLE
Split hand pin change for splinky v3

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky/config.h
@@ -21,14 +21,6 @@
 #define MATRIX_ROW_PINS \
     { GP26, GP5, GP4, GP9 }
 
-/* Handedness. */
-#define MASTER_RIGHT
-
-// To use the handedness pin, resistors need to be installed on the adapter PCB.
-// If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
-// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-
 /* serial.c configuration (for split keyboard). */
 #define SOFT_SERIAL_PIN GP1
 

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky/v2/config.h
@@ -25,3 +25,11 @@
 #define SPI_SCK_PIN GP18
 #define SPI_MOSI_PIN GP19
 #define POINTING_DEVICE_CS_PIN GP14
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky/v2/config.h
@@ -31,5 +31,5 @@
 
 // To use the handedness pin, resistors need to be installed on the adapter PCB.
 // If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN GP13
 // #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky/v3/config.h
@@ -31,5 +31,5 @@
 
 // To use the handedness pin, resistors need to be installed on the adapter PCB.
 // If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN GP15
 // #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky/v3/config.h
@@ -25,3 +25,11 @@
 #define SPI_SCK_PIN GP22
 #define SPI_MOSI_PIN GP23
 #define POINTING_DEVICE_CS_PIN GP16
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky/config.h
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky/config.h
@@ -21,14 +21,6 @@
 #define MATRIX_ROW_PINS \
     { GP26, GP5, GP4, GP9 }
 
-/* Handedness. */
-#define MASTER_RIGHT
-
-// To use the handedness pin, resistors need to be installed on the adapter PCB.
-// If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
-// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-
 /* serial.c configuration (for split keyboard). */
 #define SOFT_SERIAL_PIN GP1
 

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky/v2/config.h
@@ -33,4 +33,3 @@
 // If so, uncomment the following code, and undefine MASTER_RIGHT above.
 // #define SPLIT_HAND_PIN GP13
 // #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky/v2/config.h
@@ -25,3 +25,12 @@
 #define SPI_SCK_PIN GP18
 #define SPI_MOSI_PIN GP19
 #define POINTING_DEVICE_CS_PIN GP14
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
+

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky/v3/config.h
@@ -33,4 +33,3 @@
 // If so, uncomment the following code, and undefine MASTER_RIGHT above.
 // #define SPLIT_HAND_PIN GP15
 // #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky/v3/config.h
@@ -25,3 +25,12 @@
 #define SPI_SCK_PIN GP22
 #define SPI_MOSI_PIN GP23
 #define POINTING_DEVICE_CS_PIN GP16
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
+

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky/config.h
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky/config.h
@@ -21,14 +21,6 @@
 #define MATRIX_ROW_PINS \
     { GP29, GP26, GP5, GP4, GP9 }
 
-/* Handedness. */
-#define MASTER_RIGHT
-
-// To use the handedness pin, resistors need to be installed on the adapter PCB.
-// If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
-// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-
 /* serial.c configuration (for split keyboard). */
 #define SOFT_SERIAL_PIN GP1
 

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky/v2/config.h
@@ -33,4 +33,3 @@
 // If so, uncomment the following code, and undefine MASTER_RIGHT above.
 // #define SPLIT_HAND_PIN GP13
 // #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky/v2/config.h
@@ -25,3 +25,12 @@
 #define SPI_SCK_PIN GP18
 #define SPI_MOSI_PIN GP19
 #define POINTING_DEVICE_CS_PIN GP14
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
+

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky/v3/config.h
@@ -33,4 +33,3 @@
 // If so, uncomment the following code, and undefine MASTER_RIGHT above.
 // #define SPLIT_HAND_PIN GP15
 // #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky/v3/config.h
@@ -25,3 +25,12 @@
 #define SPI_SCK_PIN GP22
 #define SPI_MOSI_PIN GP23
 #define POINTING_DEVICE_CS_PIN GP16
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
+

--- a/keyboards/bastardkb/scylla/v2/splinky/config.h
+++ b/keyboards/bastardkb/scylla/v2/splinky/config.h
@@ -21,14 +21,6 @@
 #define MATRIX_ROW_PINS \
     { GP29, GP26, GP5, GP4, GP9 }
 
-/* Handedness. */
-#define MASTER_RIGHT
-
-// To use the handedness pin, resistors need to be installed on the adapter PCB.
-// If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
-// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-
 /* serial.c configuration (for split keyboard). */
 #define SOFT_SERIAL_PIN GP1
 

--- a/keyboards/bastardkb/scylla/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/scylla/v2/splinky/v2/config.h
@@ -20,3 +20,11 @@
 /* Key matrix configuration. */
 #define MATRIX_COL_PINS \
     { GP27, GP28, GP15, GP6, GP7, GP8 }
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/scylla/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/scylla/v2/splinky/v3/config.h
@@ -20,3 +20,11 @@
 /* Key matrix configuration. */
 #define MATRIX_COL_PINS \
     { GP27, GP28, GP21, GP6, GP7, GP8 }
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/skeletyl/v2/splinky/config.h
+++ b/keyboards/bastardkb/skeletyl/v2/splinky/config.h
@@ -21,14 +21,6 @@
 #define MATRIX_ROW_PINS \
     { GP26, GP5, GP4, GP9 }
 
-/* Handedness. */
-#define MASTER_RIGHT
-
-// To use the handedness pin, resistors need to be installed on the adapter PCB.
-// If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
-// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-
 /* serial.c configuration (for split keyboard). */
 #define SOFT_SERIAL_PIN GP1
 

--- a/keyboards/bastardkb/skeletyl/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/skeletyl/v2/splinky/v2/config.h
@@ -20,3 +20,11 @@
 /* Key matrix configuration. */
 #define MATRIX_COL_PINS \
     { GP28, GP15, GP6, GP7, GP8 }
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/skeletyl/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/skeletyl/v2/splinky/v3/config.h
@@ -20,3 +20,11 @@
 /* Key matrix configuration. */
 #define MATRIX_COL_PINS \
     { GP28, GP21, GP6, GP7, GP8 }
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/tbkmini/v2/splinky/config.h
+++ b/keyboards/bastardkb/tbkmini/v2/splinky/config.h
@@ -21,14 +21,6 @@
 #define MATRIX_ROW_PINS \
     { GP26, GP5, GP4, GP9 }
 
-/* Handedness. */
-#define MASTER_RIGHT
-
-// To use the handedness pin, resistors need to be installed on the adapter PCB.
-// If so, uncomment the following code, and undefine MASTER_RIGHT above.
-// #define SPLIT_HAND_PIN GP13
-// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.
-
 /* serial.c configuration (for split keyboard). */
 #define SOFT_SERIAL_PIN GP1
 

--- a/keyboards/bastardkb/tbkmini/v2/splinky/v2/config.h
+++ b/keyboards/bastardkb/tbkmini/v2/splinky/v2/config.h
@@ -20,3 +20,11 @@
 /* Key matrix configuration. */
 #define MATRIX_COL_PINS \
     { GP27, GP28, GP15, GP6, GP7, GP8 }
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP13
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.

--- a/keyboards/bastardkb/tbkmini/v2/splinky/v3/config.h
+++ b/keyboards/bastardkb/tbkmini/v2/splinky/v3/config.h
@@ -20,3 +20,11 @@
 /* Key matrix configuration. */
 #define MATRIX_COL_PINS \
     { GP27, GP28, GP21, GP6, GP7, GP8 }
+
+/* Handedness. */
+#define MASTER_RIGHT
+
+// To use the handedness pin, resistors need to be installed on the adapter PCB.
+// If so, uncomment the following code, and undefine MASTER_RIGHT above.
+// #define SPLIT_HAND_PIN GP15
+// #define SPLIT_HAND_PIN_LOW_IS_LEFT  // High -> right, Low -> left.


### PR DESCRIPTION
Moved the MASTER_RIGHT and the commented-out code for the SPLIT_HAND_PIN and SPLIT_HAND_PIN_LOW_IS_LEFT to the respective v2 v3 config.h files as the pin was changed from v2 to v3.