### PR TITLE
fix(chrdb.doc) typo in the snip-toggle keycode

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/keymaps/via/readme.md
+++ b/keyboards/bastardkb/charybdis/3x5/keymaps/via/readme.md
@@ -30,7 +30,7 @@ Use the `DRAGSCROLL_MODE` keycode to enable drag-scroll on hold. Use the `DRAGSC
 
 ### Sniping
 
-Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_TOGGLE` keycode to enable/disable sniping mode on key press.
+Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_MODE_TOGGLE` (aliased as `SNP_TOG`) keycode to enable/disable sniping mode on key press.
 
 Change the value of `CHARYBDIS_AUTO_SNIPING_ON_LAYER` to automatically enable sniping mode on layer change. By default, sniping mode is enabled on the pointer layer:
 

--- a/keyboards/bastardkb/charybdis/3x6/keymaps/via/readme.md
+++ b/keyboards/bastardkb/charybdis/3x6/keymaps/via/readme.md
@@ -28,7 +28,7 @@ Use the `DRAGSCROLL_MODE` keycode to enable drag-scroll on hold. Use the `DRAGSC
 
 ### Sniping
 
-Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_TOGGLE` keycode to enable/disable sniping mode on key press.
+Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_MODE_TOGGLE` (aliased as `SNP_TOG`) keycode to enable/disable sniping mode on key press.
 
 Change the value of `CHARYBDIS_AUTO_SNIPING_ON_LAYER` to automatically enable sniping mode on layer change. By default, sniping mode is enabled on the pointer layer:
 

--- a/keyboards/bastardkb/charybdis/4x6/keymaps/via/readme.md
+++ b/keyboards/bastardkb/charybdis/4x6/keymaps/via/readme.md
@@ -28,7 +28,7 @@ Use the `DRAGSCROLL_MODE` keycode to enable drag-scroll on hold. Use the `DRAGSC
 
 ### Sniping
 
-Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_TOGGLE` keycode to enable/disable sniping mode on key press.
+Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_MODE_TOGGLE` (aliased as `SNP_TOG`) keycode to enable/disable sniping mode on key press.
 
 Change the value of `CHARYBDIS_AUTO_SNIPING_ON_LAYER` to automatically enable sniping mode on layer change. By default, sniping mode is enabled on the pointer layer:
 

--- a/keyboards/bastardkb/dilemma/3x5_2/keymaps/via/readme.md
+++ b/keyboards/bastardkb/dilemma/3x5_2/keymaps/via/readme.md
@@ -38,7 +38,7 @@ To disable this, add the following to your keymap:
 
 ### Sniping
 
-Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_TOGGLE` keycode to enable/disable sniping mode on key press.
+Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_MODE_TOGGLE` (aliased as `SNP_TOG`) keycode to enable/disable sniping mode on key press.
 
 Change the value of `DILEMMA_AUTO_SNIPING_ON_LAYER` to automatically enable sniping mode on layer change. By default, sniping mode is enabled on the pointer layer:
 

--- a/keyboards/bastardkb/dilemma/3x5_3/keymaps/via/readme.md
+++ b/keyboards/bastardkb/dilemma/3x5_3/keymaps/via/readme.md
@@ -38,7 +38,7 @@ To disable this, add the following to your keymap:
 
 ### Sniping
 
-Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_TOGGLE` keycode to enable/disable sniping mode on key press.
+Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_MODE_TOGGLE` (aliased as `SNP_TOG`) keycode to enable/disable sniping mode on key press.
 
 Change the value of `DILEMMA_AUTO_SNIPING_ON_LAYER` to automatically enable sniping mode on layer change. By default, sniping mode is enabled on the pointer layer:
 

--- a/keyboards/bastardkb/dilemma/4x6_4/keymaps/via/readme.md
+++ b/keyboards/bastardkb/dilemma/4x6_4/keymaps/via/readme.md
@@ -38,7 +38,7 @@ To disable this, add the following to your keymap:
 
 ### Sniping
 
-Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_TOGGLE` keycode to enable/disable sniping mode on key press.
+Use the `SNIPING_MODE` keycode to enable sniping mode on hold. Use the `SNIPING_MODE_TOGGLE` (aliased as `SNP_TOG`) keycode to enable/disable sniping mode on key press.
 
 Change the value of `DILEMMA_AUTO_SNIPING_ON_LAYER` to automatically enable sniping mode on layer change. By default, sniping mode is enabled on the pointer layer:
 


### PR DESCRIPTION
As explained in [this thread](https://discordapp.com/channels/681309835135811648/1168814104316751944/1194937795467296829), there is a typo in the docs where [it mentions](https://github.com/Bastardkb/bastardkb-qmk/blob/bkb-master/keyboards/bastardkb/charybdis/4x6/keymaps/via/readme.md)  the `SNIPING_TOGGLE` keycode, but there is no such symbol in the recent bkb-master sources.  The correct symbol  is called `SNP_TOG` and `SNIPING_MODE_TOGGLE` in `charybdis.h`.

All readmes have this typo.