### PR TITLE
Bkb charybdis tuned

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/keymaps/via/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/keymaps/via/config.h
@@ -18,7 +18,7 @@
 
 #ifdef VIA_ENABLE
 /* VIA configuration. */
-#    define DYNAMIC_KEYMAP_LAYER_COUNT 7
+#    define DYNAMIC_KEYMAP_LAYER_COUNT 8
 #endif // VIA_ENABLE
 
 #ifndef __arm__

--- a/keyboards/bastardkb/charybdis/3x5/keymaps/via/keymap.c
+++ b/keyboards/bastardkb/charybdis/3x5/keymaps/via/keymap.c
@@ -183,11 +183,14 @@ ESC_MED, SPC_NAV, TAB_FUN, ENT_SYM, BSP_NUM
 #define _HOME_ROW_MOD_GACS(                                            \
     L00, L01, L02, L03, L04, R05, R06, R07, R08, R09,                  \
     L10, L11, L12, L13, L14, R15, R16, R17, R18, R19,                  \
+    L20, L21, L22, L23, L24, R25, R26, R27, R28, R29,                  \
     ...)                                                               \
              L00,         L01,         L02,         L03,         L04,  \
              R05,         R06,         R07,         R08,         R09,  \
       LGUI_T(L10), LALT_T(L11), LCTL_T(L12), LSFT_T(L13),        L14,  \
              R15,  RSFT_T(R16), RCTL_T(R17), LALT_T(R18), RGUI_T(R19), \
+             L20,         L21,         L22,  RALT_T(L23),        L24, \
+             R25,  RALT_T(R26),        R27,         R28,         R29, \
       __VA_ARGS__
 #define HOME_ROW_MOD_GACS(...) _HOME_ROW_MOD_GACS(__VA_ARGS__)
 

--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -58,6 +58,7 @@ typedef union {
         uint8_t pointer_sniping_dpi : 2; // 4 steps available.
         bool    is_dragscroll_enabled : 1;
         bool    is_sniping_enabled : 1;
+        bool    is_pointing_device_enabled : 1;
     } __attribute__((packed));
 } charybdis_config_t;
 
@@ -72,9 +73,10 @@ static charybdis_config_t g_charybdis_config = {0};
  * explicitly set them to `false` in this function.
  */
 static void read_charybdis_config_from_eeprom(charybdis_config_t* config) {
-    config->raw                   = eeconfig_read_kb() & 0xff;
-    config->is_dragscroll_enabled = false;
-    config->is_sniping_enabled    = false;
+    config->raw                        = eeconfig_read_kb() & 0xff;
+    config->is_dragscroll_enabled      = false;
+    config->is_sniping_enabled         = false;
+    config->is_pointing_device_enabled = false;
 }
 
 /**
@@ -176,6 +178,14 @@ void charybdis_set_pointer_dragscroll_enabled(bool enable) {
     maybe_update_pointing_device_cpi(&g_charybdis_config);
 }
 
+void charybdis_set_pointing_device_enabled(bool enable) {
+    g_charybdis_config.is_pointing_device_enabled = enable;
+}
+
+bool charybdis_get_pointing_device_enabled(void) {
+    return g_charybdis_config.is_pointing_device_enabled;
+}
+
 /**
  * \brief Augment the pointing device behavior.
  *
@@ -184,6 +194,7 @@ void charybdis_set_pointer_dragscroll_enabled(bool enable) {
 static void pointing_device_task_charybdis(report_mouse_t* mouse_report) {
     static int16_t scroll_buffer_x = 0;
     static int16_t scroll_buffer_y = 0;
+
     if (g_charybdis_config.is_dragscroll_enabled) {
 #    ifdef CHARYBDIS_DRAGSCROLL_REVERSE_X
         scroll_buffer_x -= mouse_report->x;

--- a/keyboards/bastardkb/charybdis/charybdis.h
+++ b/keyboards/bastardkb/charybdis/charybdis.h
@@ -108,4 +108,15 @@ bool charybdis_get_pointer_dragscroll_enabled(void);
  * are translated into horizontal and vertical scroll movements.
  */
 void charybdis_set_pointer_dragscroll_enabled(bool enable);
+
+/**
+ * \brief Enable/disable pointer if in mouse layer
+ */
+void charybdis_set_pointing_device_enabled(bool enable);
+
+/**
+ * \brief Return whether pointer is enabled
+ */
+bool charybdis_get_pointing_device_enabled(void);
+
 #endif // POINTING_DEVICE_ENABLE

--- a/keyboards/bastardkb/charybdis/config.h
+++ b/keyboards/bastardkb/charybdis/config.h
@@ -18,8 +18,23 @@
 
 #pragma once
 
+/* Keyboard configuration. */
+#define TAPPING_TERM 200
+#define TAPPING_TERM_GUI 600
+#define TAPPING_TERM_PER_KEY
+/* #define CHARYBDIS_LAYOUT_COLEMAK_DHM */
+#define CHARYBDIS_ENABLE_POINTER_ON_POINTER_LAYER_ONLY
+#define CHARYBDIS_AUTO_POINTER_LAYER_TRIGGER_ENABLE
+#define CHARYBDIS_AUTO_POINTER_LAYER_TRIGGER_THRESHOLD 2
+#define CHARYBDIS_AUTO_POINTER_LAYER_TRIGGER_TIMEOUT_MS 600
 
 /* Pointing device configuration. */
+
+// Set the minimum mouse speed when sniping.
+#define CHARYBDIS_MINIMUM_SNIPING_DPI 100
+
+// Invert Y axis on drag scroll.
+#define CHARYBDIS_DRAGSCROLL_REVERSE_Y
 
 // Enable use of pointing device on slave split.
 #define SPLIT_POINTING_ENABLE


### PR DESCRIPTION
**This adds the following features:**

-  the trackball is dynamically enabled/disabled by moving it over a set threshold - this prevents accidential pointer movement especially when pressing keys that need reaching over the trackball 
-  separate timing for tap-hold on the gui  key to prevent accidential triggering
- AltGr key on third row index finger hold to enable umlauts 

`CHARYBDIS_ENABLE_POINTER_ON_POINTER_LAYER_ONLY` combined with `CHARYBDIS_AUTO_POINTER_LAYER_TRIGGER_ENABLE` makes the trackball enable/disable automatically. This prevents auto shiping.

Without **CHARYBDIS_AUTO_POINTER_LAYER_TRIGGER_ENABLE** it disables the trackball until the pointer layer is enabled manually.

Without both the trackball will constantly be enabled.

The actition threshold should feel smoth but might need some fine tuning depending on your DPI settings.

**This adds the following bug fixes:**

- pointer stopping mid movement when using `CHARYBDIS_AUTO_POINTER_LAYER_TRIGGER_ENABLE`

**ATTENTION: This introduces a suparate layer for auto pointer which might interfere with layer checks! This is needed for keeping the pointer enabled when auto enabling it and then additionally shifting to pointer layer manually.**