### PR TITLE
fix: preserve accumulated drag-scroll distance, queued or coalesced

### DIFF
--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -197,14 +197,21 @@ static void pointing_device_task_charybdis(report_mouse_t* mouse_report) {
 #    endif // CHARYBDIS_DRAGSCROLL_REVERSE_Y
         mouse_report->x = 0;
         mouse_report->y = 0;
-        if (abs(scroll_buffer_x) > CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
-            mouse_report->h = scroll_buffer_x > 0 ? 1 : -1;
-            scroll_buffer_x = 0;
+        if (abs(scroll_buffer_x) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
+            const int16_t sign_x = scroll_buffer_x > 0 ? 1 : -1;
+            mouse_report->h = sign_x;
+            scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
         }
-        if (abs(scroll_buffer_y) > CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
-            mouse_report->v = scroll_buffer_y > 0 ? 1 : -1;
-            scroll_buffer_y = 0;
+        if (abs(scroll_buffer_y) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
+            const int16_t sign_y = scroll_buffer_y > 0 ? 1 : -1;
+            mouse_report->v = sign_y;
+            scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
         }
+
+        mouse_report->x = mouse_report->y = 0;
+    } else {  // not a drag-scroll event
+        // Clean up, or next draa-scroll actevation would start abruptly.
+        scroll_buffer_x =  scroll_buffer_y = 0;
     }
 }
 

--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -186,32 +186,45 @@ static void pointing_device_task_charybdis(report_mouse_t* mouse_report) {
     static int16_t scroll_buffer_y = 0;
     if (g_charybdis_config.is_dragscroll_enabled) {
 #    ifdef CHARYBDIS_DRAGSCROLL_REVERSE_X
-        scroll_buffer_x -= mouse_report->x;
+        const int16_t m_x = -mouse_report->x;
 #    else
-        scroll_buffer_x += mouse_report->x;
+        const int16_t m_x = mouse_report->x;
 #    endif // CHARYBDIS_DRAGSCROLL_REVERSE_X
 #    ifdef CHARYBDIS_DRAGSCROLL_REVERSE_Y
-        scroll_buffer_y -= mouse_report->y;
+        const int16_t m_y = -mouse_report->y;
 #    else
-        scroll_buffer_y += mouse_report->y;
+        const int16_t m_y = mouse_report->y;
 #    endif // CHARYBDIS_DRAGSCROLL_REVERSE_Y
-        mouse_report->x = 0;
-        mouse_report->y = 0;
+        scroll_buffer_x += m_x;
+        scroll_buffer_y += m_y;
+
         if (abs(scroll_buffer_x) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
             const int16_t sign_x = scroll_buffer_x > 0 ? 1 : -1;
-            mouse_report->h = sign_x;
-            scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
+            mouse_report->h      = sign_x;
+            if (m_x == 0 || ((m_x > 0) && (scroll_buffer_x > 0)) || ((m_x < 0) && (scroll_buffer_x < 0))) {
+                // Spill-over accumulated distance to the next cycle.
+                scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
+            } else {
+                // Cancel accunulated distance if mouse-direction reversed.
+                scroll_buffer_x = 0;
+            }
         }
         if (abs(scroll_buffer_y) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
             const int16_t sign_y = scroll_buffer_y > 0 ? 1 : -1;
-            mouse_report->v = sign_y;
-            scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
+            mouse_report->v      = sign_y;
+            if (m_y == 0 || ((m_y > 0) && (scroll_buffer_y > 0)) || ((m_y < 0) && (scroll_buffer_y < 0))) {
+                // Spill-over accumulated distance to the next cycle.
+                scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
+            } else {
+                // Cancel accunulated distance if mouse-direction reversed.
+                scroll_buffer_y = 0;
+            }
         }
 
         mouse_report->x = mouse_report->y = 0;
-    } else {  // not a drag-scroll event
+    } else { // not a drag-scroll event
         // Clean up, or next draa-scroll actevation would start abruptly.
-        scroll_buffer_x =  scroll_buffer_y = 0;
+        scroll_buffer_x = scroll_buffer_y = 0;
     }
 }
 

--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -196,10 +196,16 @@ static void pointing_device_task_charybdis(report_mouse_t* mouse_report) {
         } else {
             scroll_buffer_x += m_x;
         }
-        if (abs(scroll_buffer_x) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
+        const int16_t abs_x = abs(scroll_buffer_x);
+        if (abs_x >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
             const int16_t sign_x = scroll_buffer_x > 0 ? 1 : -1;
-            mouse_report->h      = sign_x;
-            scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE; // Spill-over
+#    ifdef CHARYBDIS_DRAGSCROLL_SEND_COALESCED
+            mouse_report->h = sign_x * (abs_x / CHARYBDIS_DRAGSCROLL_BUFFER_SIZE);
+            scroll_buffer_x = sign_x * (abs_x % CHARYBDIS_DRAGSCROLL_BUFFER_SIZE);
+#    else
+            mouse_report->h = sign_x;
+            scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
+#    endif // CHARYBDIS_DRAGSCROLL_SEND_COALESCED
         }
 
 #    ifdef CHARYBDIS_DRAGSCROLL_REVERSE_Y
@@ -213,10 +219,16 @@ static void pointing_device_task_charybdis(report_mouse_t* mouse_report) {
         } else {
             scroll_buffer_y += m_y;
         }
-        if (abs(scroll_buffer_y) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
+        const int16_t abs_y = abs(scroll_buffer_y);
+        if (abs_y >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
             const int16_t sign_y = scroll_buffer_y > 0 ? 1 : -1;
-            mouse_report->v      = sign_y;
-            scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE; // Spill-over
+#    ifdef CHARYBDIS_DRAGSCROLL_SEND_COALESCED
+            mouse_report->v = sign_y * (abs_y / CHARYBDIS_DRAGSCROLL_BUFFER_SIZE);
+            scroll_buffer_y = sign_y * (abs_y % CHARYBDIS_DRAGSCROLL_BUFFER_SIZE);
+#    else
+            mouse_report->v = sign_y;
+            scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
+#    endif // CHARYBDIS_DRAGSCROLL_SEND_COALESCED
         }
 
         mouse_report->x = mouse_report->y = 0;

--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -190,35 +190,33 @@ static void pointing_device_task_charybdis(report_mouse_t* mouse_report) {
 #    else
         const int16_t m_x = mouse_report->x;
 #    endif // CHARYBDIS_DRAGSCROLL_REVERSE_X
+        if (((m_x > 0) && (scroll_buffer_x < 0)) || ((m_x < 0) && (scroll_buffer_x > 0))) {
+            // Immediately cancel accunulated distance if mouse-direction reversed.
+            scroll_buffer_x = m_x;
+        } else {
+            scroll_buffer_x += m_x;
+        }
+        if (abs(scroll_buffer_x) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
+            const int16_t sign_x = scroll_buffer_x > 0 ? 1 : -1;
+            mouse_report->h      = sign_x;
+            scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE; // Spill-over
+        }
+
 #    ifdef CHARYBDIS_DRAGSCROLL_REVERSE_Y
         const int16_t m_y = -mouse_report->y;
 #    else
         const int16_t m_y = mouse_report->y;
 #    endif // CHARYBDIS_DRAGSCROLL_REVERSE_Y
-        scroll_buffer_x += m_x;
-        scroll_buffer_y += m_y;
-
-        if (abs(scroll_buffer_x) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
-            const int16_t sign_x = scroll_buffer_x > 0 ? 1 : -1;
-            mouse_report->h      = sign_x;
-            if (m_x == 0 || ((m_x > 0) && (scroll_buffer_x > 0)) || ((m_x < 0) && (scroll_buffer_x < 0))) {
-                // Spill-over accumulated distance to the next cycle.
-                scroll_buffer_x -= sign_x * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
-            } else {
-                // Cancel accunulated distance if mouse-direction reversed.
-                scroll_buffer_x = 0;
-            }
+        if (((m_y > 0) && (scroll_buffer_y < 0)) || ((m_y < 0) && (scroll_buffer_y > 0))) {
+            // Immediately cancel accunulated distance if mouse-direction reversed.
+            scroll_buffer_y = m_y;
+        } else {
+            scroll_buffer_y += m_y;
         }
         if (abs(scroll_buffer_y) >= CHARYBDIS_DRAGSCROLL_BUFFER_SIZE) {
             const int16_t sign_y = scroll_buffer_y > 0 ? 1 : -1;
             mouse_report->v      = sign_y;
-            if (m_y == 0 || ((m_y > 0) && (scroll_buffer_y > 0)) || ((m_y < 0) && (scroll_buffer_y < 0))) {
-                // Spill-over accumulated distance to the next cycle.
-                scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE;
-            } else {
-                // Cancel accunulated distance if mouse-direction reversed.
-                scroll_buffer_y = 0;
-            }
+            scroll_buffer_y -= sign_y * CHARYBDIS_DRAGSCROLL_BUFFER_SIZE; // Spill-over
         }
 
         mouse_report->x = mouse_report->y = 0;

--- a/keyboards/bastardkb/charybdis/readme.md
+++ b/keyboards/bastardkb/charybdis/readme.md
@@ -86,8 +86,15 @@ To invert the vertical scrolling direction (_ie._ mimic macOS "natural" scroll d
 ```c
 #define CHARYBDIS_DRAGSCROLL_REVERSE_Y
 ```
-
 This only affects the vertical scroll direction.
+
+
+By default, accumulated drag-scroll ±1 events from fast moves are queued and send through even after "wheel" has stopped moving.  To send scroll-wheel events with values greater than ±1,
+define `CHARYBDIS_DRAGSCROLL_SEND_COALESCED`:
+
+```c
+#define CHARYBDIS_DRAGSCROLL_SEND_COALESCED
+```
 
 ### Sniping mode
 


### PR DESCRIPTION
The job of the Drag-scroll distance-accumulating buffer is to reduce mouse's input-distance by dividing it by `CHARYBDIS_DRAGSCROLL_BUFFER_SIZE`.

### Problem (fixed)

Before this PR, when the buffer was full (`accumulated-distance > CHARYBDIS_DRAGSCROLL_BUFFER_SIZE`),
a ±1 wheel-event was emitted and the spill-over distance was dumped,
beginning the next accumulation cycle (every `POINTING_DEVICE_TASK_THROTTLE_MS`) always from 0.

In other words, the distance division was getting rid of the remainder,
which at times can be above 1000!
This effectively caps the attainable scroll-speed.

With sensible defaults (SCROLL_DPI: 100), the effect was a subtle jerk and capped scrolling speed,
but in higher DPIs, or with mouse-acceleration[1] enabled, and feeding to drag-scroll,
all expected additional velocity was simply lost[2].

### Feature added

This PR additionally retrofits the drag-scroll with a new config  `CHARYBDIS_DRAGSCROLL_SEND_COALESCED`
that controls how accumulated drag-scroll distance from fast moves are emitted:
- _undefined:_  queued and emitted as ±1 events 
  even after "wheel" has stopped moving;  scrolling in the opposite direction will immediately cancel any queued events;
- _defined:_ scroll-wheel events with values greater than ±1 are immediately emitted.

### Mouse acceleration

To enjoy this you need a potent source of mouse distance, like the Mouse acceleration mod[2] ("maccel").
But bkb code in `keyboards/bastardkb/charybdis/charybdis.c:pointing_device_task_kb()` drives the user task
(where the maccel runs) _after_ drag-scroll code, so you have to reverse the x2 lines in the above function
into this:

```c
report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report) {
    if (is_keyboard_master()) {
        mouse_report = pointing_device_task_user(mouse_report);
        pointing_device_task_charybdis(&mouse_report);
    }
    return mouse_report;
}
```


[1]: https://github.com/finrod09/qmk_userspace_features/tree/maccel-assym_s_curve/maccel
[2]: https://discord.com/channels/681309835135811648/1203417572742135808/1209541956422598699
