### PR TITLE
Dilemma workaround: reduce soft serial speed

### DIFF
--- a/keyboards/bastardkb/dilemma/3x5_3/config.h
+++ b/keyboards/bastardkb/dilemma/3x5_3/config.h
@@ -120,3 +120,6 @@
 #    define ENABLE_RGB_MATRIX_SOLID_SPLASH
 #    define ENABLE_RGB_MATRIX_SOLID_MULTISPLASH
 #endif
+
+// Reduce soft serial speed: Work around rp2040 issues
+#define SELECT_SOFT_SERIAL_SPEED 4

--- a/keyboards/bastardkb/dilemma/4x6_4/config.h
+++ b/keyboards/bastardkb/dilemma/4x6_4/config.h
@@ -52,3 +52,6 @@
 // Startup values.
 #define RGB_MATRIX_DEFAULT_VAL 64
 #define RGB_MATRIX_DEFAULT_SPD 32
+
+// Reduce soft serial speed: Work around rp2040 issues
+#define SELECT_SOFT_SERIAL_SPEED 4


### PR DESCRIPTION
## Description

The rp2040 half duplex serial implementation using the `vendor` driver is flawed. On an otherwise unmodified stock firmware with serial debugging enabled, somewhat frequent failed handshakes can be observed on the Dilemma v2 and Dilemma Max.

Until now, this had no observable effects in general use. The upcoming qmk breaking changes merge contains 
#21548, which exacerbates the issue and leads to spurious encoder events being generated, most often direction 0 for encoder 0, meaning a stock Dilemma will randomly scroll up.

Testing has revealed 38400 Bd to be stable with no observable downside on the Dilemma and Dilemma Max.

Credit/Thanks to:
- Drashna for leading me to the cause of the spurious encoder events I was observing, and linking past discussion on this problem
- Yingeling for reproducing on more hardware

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix (rather: *workaround*)
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
