### PR TITLE
configure bootmagic

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/info.json
@@ -5,6 +5,11 @@
         "pid": "0x1832",
         "vid": "0xA8F8"
     },
+    "split": {
+        "bootmagic": {
+            "matrix": [4, 0]
+        }
+    },
     "layout_aliases": {
         "LAYOUT_charybdis_3x5": "LAYOUT"
     },

--- a/keyboards/bastardkb/charybdis/3x6/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/info.json
@@ -3,6 +3,11 @@
     "usb": {
         "pid": "0x1834"
     },
+    "split": {
+        "bootmagic": {
+            "matrix": [4, 0]
+        }
+    },
     "layout_aliases": {
         "LAYOUT_charybdis_3x6": "LAYOUT"
     },

--- a/keyboards/bastardkb/charybdis/4x6/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/info.json
@@ -5,6 +5,11 @@
         "pid": "0x1833",
         "vid": "0xA8F8"
     },
+    "split": {
+        "bootmagic": {
+            "matrix": [5, 0]
+        }
+    },
     "layout_aliases": {
         "LAYOUT_charybdis_4x6": "LAYOUT"
     },

--- a/keyboards/bastardkb/scylla/info.json
+++ b/keyboards/bastardkb/scylla/info.json
@@ -7,6 +7,11 @@
         "led_count": 58,
         "split_count": [29, 29]
     },
+    "split": {
+        "bootmagic": {
+            "matrix": [5, 0]
+        }
+    },
     "layouts": {
         "LAYOUT_split_4x6_5": {
             "layout": [

--- a/keyboards/bastardkb/skeletyl/info.json
+++ b/keyboards/bastardkb/skeletyl/info.json
@@ -7,6 +7,11 @@
         "led_count": 36,
         "split_count": [18, 18]
     },
+    "split": {
+        "bootmagic": {
+            "matrix": [4, 0]
+        }
+    },
     "community_layouts": ["split_3x5_3"],
     "layouts": {
         "LAYOUT_split_3x5_3": {

--- a/keyboards/bastardkb/tbkmini/info.json
+++ b/keyboards/bastardkb/tbkmini/info.json
@@ -7,6 +7,11 @@
         "led_count": 42,
         "split_count": [21, 21]
     },
+    "split": {
+        "bootmagic": {
+            "matrix": [4, 0]
+        }
+    },
     "community_layouts": ["split_3x6_3"],
     "layouts": {
         "LAYOUT_split_3x6_3": {


### PR DESCRIPTION
This change configures bootmagic for the Dactyl and Charybdis families.

Previously, it would default to [0,0], which since the boards use master right, would require holding the top pinky key on the slave, which places the slave in bootloader mode, which is not helpful.

Tested in hardware on Charybdis 4x6 and 3x5.