### PR TITLE
set DEFAULT_FOLDER for charybdises and dactyls

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = bastardkb/charybdis/3x5/v2/splinky_3

--- a/keyboards/bastardkb/charybdis/3x6/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = bastardkb/charybdis/3x6/v2/splinky_3

--- a/keyboards/bastardkb/charybdis/4x6/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = bastardkb/charybdis/4x6/v2/splinky_3

--- a/keyboards/bastardkb/scylla/rules.mk
+++ b/keyboards/bastardkb/scylla/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = bastardkb/scylla/v2/splinky_3

--- a/keyboards/bastardkb/skeletyl/rules.mk
+++ b/keyboards/bastardkb/skeletyl/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = bastardkb/skeletyl/v2/splinky_3

--- a/keyboards/bastardkb/tbkmini/rules.mk
+++ b/keyboards/bastardkb/tbkmini/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = bastardkb/tbkmini/v2/splinky_3


### PR DESCRIPTION
Sets DEFAULT_FOLDER to the v2/splinky_3 variant as default, enabling eg. `qmk compile -kb bastardkb/charybdis/3x6 -km via`