### PR TITLE
Data-Driven conversion pt2

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/info.json
@@ -24,7 +24,10 @@
     },
     "features": {
         "bootmagic": true,
+        "mousekey": false,
         "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     }
     "ws2812": {
         "pin": "GP0",

--- a/keyboards/bastardkb/charybdis/3x5/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/rules.mk
@@ -4,11 +4,9 @@
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = yes  # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = yes    # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SPLIT_KEYBOARD = yes
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/3x6/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/info.json
@@ -22,7 +22,10 @@
     },
     "features": {
         "bootmagic": true,
+        "mousekey": false,
         "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     }
     "ws2812": {
         "pin": "GP0",

--- a/keyboards/bastardkb/charybdis/3x6/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/rules.mk
@@ -4,11 +4,9 @@
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = yes  # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = yes    # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SPLIT_KEYBOARD = yes
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/4x6/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/info.json
@@ -24,7 +24,10 @@
     },
     "features": {
         "bootmagic": true,
+        "mousekey": false,
         "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true,
     }
     "ws2812": {
         "pin": "GP0",

--- a/keyboards/bastardkb/charybdis/4x6/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/rules.mk
@@ -4,11 +4,9 @@
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = yes  # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = yes    # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SPLIT_KEYBOARD = yes
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/dilemma/3x5_2/info.json
+++ b/keyboards/bastardkb/dilemma/3x5_2/info.json
@@ -4,6 +4,12 @@
         "device_version": "1.0.0",
         "pid": "0x1835"
     },
+     "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "pointing_device": true
+    },
     "matrix_pins": {
         "cols": ["GP8", "GP9", "GP7", "GP6", "GP27"],
         "rows": ["GP4", "GP5", "GP28", "GP26"]

--- a/keyboards/bastardkb/dilemma/3x5_2/rules.mk
+++ b/keyboards/bastardkb/dilemma/3x5_2/rules.mk
@@ -1,24 +1,12 @@
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = no   # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = no     # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = no      # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi # Assembled version uses SPI.
 
 SPLIT_KEYBOARD = yes

--- a/keyboards/bastardkb/dilemma/3x5_3/config.h
+++ b/keyboards/bastardkb/dilemma/3x5_3/config.h
@@ -29,12 +29,6 @@
 #define CRC8_USE_TABLE
 #define CRC8_OPTIMIZE_SPEED
 
-/* Encoders. */
-#define ENCODERS_PAD_A \
-    { GP25 }
-#define ENCODERS_PAD_B \
-    { GP24 }
-
 /* Cirque trackpad over SPI. */
 #define SPI_DRIVER SPID0
 #define SPI_SCK_PIN GP22

--- a/keyboards/bastardkb/dilemma/3x5_3/info.json
+++ b/keyboards/bastardkb/dilemma/3x5_3/info.json
@@ -38,6 +38,7 @@
         "mousekey": true,
         "nkro": true,
         "rgb_matrix": true,
+        "pointing_device": true,
         "caps_word": true,
         "tri_layer": true
     },

--- a/keyboards/bastardkb/dilemma/3x5_3/rules.mk
+++ b/keyboards/bastardkb/dilemma/3x5_3/rules.mk
@@ -1,4 +1,3 @@
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi

--- a/keyboards/bastardkb/dilemma/4x6_4/config.h
+++ b/keyboards/bastardkb/dilemma/4x6_4/config.h
@@ -43,8 +43,5 @@
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP17
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U
 
-/* RGB matrix support. */
-#define SPLIT_TRANSPORT_MIRROR
-
 // Reduce soft serial speed: Work around rp2040 issues
 #define SELECT_SOFT_SERIAL_SPEED 4

--- a/keyboards/bastardkb/dilemma/4x6_4/info.json
+++ b/keyboards/bastardkb/dilemma/4x6_4/info.json
@@ -38,6 +38,7 @@
         "mousekey": true,
         "nkro": true,
         "rgb_matrix": true,
+        "pointing_device": true,
         "caps_word": true,
         "tri_layer": true
     },

--- a/keyboards/bastardkb/dilemma/4x6_4/rules.mk
+++ b/keyboards/bastardkb/dilemma/4x6_4/rules.mk
@@ -1,4 +1,3 @@
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi

--- a/keyboards/bastardkb/scylla/info.json
+++ b/keyboards/bastardkb/scylla/info.json
@@ -33,7 +33,9 @@
     },
     "features": {
         "bootmagic": true,
+        "mousekey": false,
         "extrakey": true,
+        "rgb_matrix": true
     }
     "ws2812": {
         "pin": "GP0",

--- a/keyboards/bastardkb/scylla/rules.mk
+++ b/keyboards/bastardkb/scylla/rules.mk
@@ -4,7 +4,6 @@
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = yes  # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = yes    # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SPLIT_KEYBOARD = yes
 

--- a/keyboards/bastardkb/skeletyl/info.json
+++ b/keyboards/bastardkb/skeletyl/info.json
@@ -33,7 +33,9 @@
     },
     "features": {
         "bootmagic": true,
+        "mousekey": false,
         "extrakey": true,
+        "rgb_matrix": true
     }
     "ws2812": {
         "pin": "GP0",

--- a/keyboards/bastardkb/skeletyl/rules.mk
+++ b/keyboards/bastardkb/skeletyl/rules.mk
@@ -4,7 +4,6 @@
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = yes  # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = yes    # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SPLIT_KEYBOARD = yes
 

--- a/keyboards/bastardkb/tbkmini/info.json
+++ b/keyboards/bastardkb/tbkmini/info.json
@@ -33,7 +33,9 @@
     },
     "features": {
         "bootmagic": true,
+        "mousekey": false,
         "extrakey": true,
+        "rgb_matrix": true
     }
     "ws2812": {
         "pin": "GP0",

--- a/keyboards/bastardkb/tbkmini/rules.mk
+++ b/keyboards/bastardkb/tbkmini/rules.mk
@@ -4,7 +4,6 @@
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = yes  # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = yes    # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SPLIT_KEYBOARD = yes
 


### PR DESCRIPTION
This change ports the remaining changes from qmk#23622 into the new flattened structure.

Additionally, it fixes two warnings resulting from options duplicated between config.h and info.json by removing the config.h variant:
- on dilemma 3x5_3, the encoder was specified in both formats, config.h being reintroduced by a conflict resolution
- on dilemma 4_6_4, the split transport mirror was specified in both formats, apparently introduced in qmk#22806