### PR TITLE
Dactyl family: Remove instructions for nonexistant via keymap from readmes

### DIFF
--- a/keyboards/bastardkb/scylla/readme.md
+++ b/keyboards/bastardkb/scylla/readme.md
@@ -11,12 +11,12 @@ A modern, low-profile split ergonomic keyboard
 The template is:
 
 ```shell
-qmk compile -kb bastardkb/scylla/{VERSION}/elitec -km {KEYMAP}
+qmk compile -kb bastardkb/scylla -km {KEYMAP}
 ```
 
-| default                                             | via                                             |
-| --------------------------------------------------- | ----------------------------------------------- |
-| `qmk compile -kb bastardkb/scylla -km default`      | `qmk compile -kb bastardkb/scylla -km via`      |
+| default                                             |
+| --------------------------------------------------- |
+| `qmk compile -kb bastardkb/scylla -km default`      |
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 

--- a/keyboards/bastardkb/skeletyl/readme.md
+++ b/keyboards/bastardkb/skeletyl/readme.md
@@ -11,12 +11,12 @@ A very small keyboard made for ergonomic enthusiasts.
 The template is:
 
 ```shell
-qmk compile -kb bastardkb/skeletyl/{VERSION}/elitec -km {KEYMAP}
+qmk compile -kb bastardkb/skeletyl -km {KEYMAP}
 ```
 
-| default                                            | via                                            |
-| -------------------------------------------------- | ---------------------------------------------- |
-| `qmk compile -kb bastardkb/skeletyl -km default`   | `qmk compile -kb bastardkb/skeletyl -km via`   |
+| default                                            |
+| -------------------------------------------------- |
+| `qmk compile -kb bastardkb/skeletyl -km default`   |
 
 This keyboard is made to be used with the Miryoku layout, do not use the default keymap.
 

--- a/keyboards/bastardkb/tbkmini/readme.md
+++ b/keyboards/bastardkb/tbkmini/readme.md
@@ -11,12 +11,12 @@ A split, compact ergonomic keyboard.
 The template is:
 
 ```shell
-qmk compile -kb bastardkb/tbkmini/{VERSION}/elitec -km {KEYMAP}
+qmk compile -kb bastardkb/tbkmini -km {KEYMAP}
 ```
 
-| default                                              | via                                              |
-| ---------------------------------------------------- | ------------------------------------------------ |
-| `qmk compile -kb bastardkb/tbkmini -km default`      | `qmk compile -kb bastardkb/tbkmini -km via`      |
+| default                                              |
+| ---------------------------------------------------- |
+| `qmk compile -kb bastardkb/tbkmini -km default`      |
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 


### PR DESCRIPTION
as per title

Also fixes a remnant reference to `elitec`.