### PR TITLE
How to compile with oled support? (ssd1306)

### DIFF
--- a/build-dilemma-firmware.sh
+++ b/build-dilemma-firmware.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+keyboard=bastardkb/dilemma/3x5_3
+model=default
+
+firmware="${keyboard////_}_${model}.uf2"
+
+function copy_firmware() {
+
+    printf >&2 'please connect %s and press the reset button twice\n' "${1}"
+    qmk flash -kb "${keyboard}" -km "${model}"
+    sync
+    sleep 1
+}
+
+rm -f "${firmware}"
+
+qmk compile -c -kb "${keyboard}" -km "${model}"
+
+exit 0
+
+printf >&2 'Copying firmware, please disconnect all cables first\n'
+copy_firmware 'right side'
+copy_firmware 'left side'
+printf >&2 "Done!"
+
+

--- a/keyboards/bastardkb/dilemma/3x5_3/mcuconf.h
+++ b/keyboards/bastardkb/dilemma/3x5_3/mcuconf.h
@@ -21,3 +21,6 @@
 
 #undef RP_SPI_USE_SPI0
 #define RP_SPI_USE_SPI0 TRUE
+
+#undef RP_I2C_USE_I2C1
+#define RP_I2C_USE_I2C1 TRUE

--- a/keyboards/bastardkb/dilemma/3x5_3/rules.mk
+++ b/keyboards/bastardkb/dilemma/3x5_3/rules.mk
@@ -1,3 +1,5 @@
 SERIAL_DRIVER = vendor
 
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi
+
+OLED_ENABLE = yes


### PR DESCRIPTION
I have added an ssd1306 oled screen on the left side of my dilemmav2 and would like to use it do display things (e.g. which layer is active). I think I have added the necessary settings, but I am not gettiing QMK to compile.

With this PR/question I want to have a minimal working oled setup (whether this PR is merged or not).

I have tried the following things:

1. compile `bkb-master` without changes (commit `f4166fca22`): this works

2. [add `ENABLE_OLED = yes`](https://docs.qmk.fm/features/oled_driver) to `keyboards/bastardkb/dilemma/3x5_3/rules.mk`: I get the following errors:
```
platforms/chibios/drivers/i2c_master.c:74:24: error: 'I2CD1' undeclared (first use in this function); did you mean 'I2C1'?
   74 | #    define I2C_DRIVER I2CD1
      |                        ^~~~~
...
platforms/chibios/drivers/i2c_master.c:37:26: error: 'B6' undeclared (first use in this function)
   37 | #    define I2C1_SCL_PIN B6
      |                          ^~
...
platforms/chibios/drivers/i2c_master.c:40:26: error: 'B7' undeclared (first use in this function)
   40 | #    define I2C1_SDA_PIN B7
      |                          ^~
```

3. add `#define RP_I2C_USE_I2C1 TRUE` (and undefine before it) to `keyboards/bastardkb/dilemma/3x5_3/mcuconf.h`: The error for `I2CD1 undeclared` disappears, but the ones about `B6` and `B7` remain.

What kind of settings am I missing? 