### PR TITLE
Enable mouse keys for charybdises and dactyls

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/keyboard.json
+++ b/keyboards/bastardkb/charybdis/3x5/keyboard.json
@@ -24,7 +24,7 @@
     },
     "features": {
         "bootmagic": true,
-        "mousekey": false,
+        "mousekey": true,
         "extrakey": true,
         "rgb_matrix": true,
         "pointing_device": true

--- a/keyboards/bastardkb/charybdis/3x6/keyboard.json
+++ b/keyboards/bastardkb/charybdis/3x6/keyboard.json
@@ -22,7 +22,7 @@
     },
     "features": {
         "bootmagic": true,
-        "mousekey": false,
+        "mousekey": true,
         "extrakey": true,
         "rgb_matrix": true,
         "pointing_device": true

--- a/keyboards/bastardkb/charybdis/4x6/keyboard.json
+++ b/keyboards/bastardkb/charybdis/4x6/keyboard.json
@@ -24,7 +24,7 @@
     },
     "features": {
         "bootmagic": true,
-        "mousekey": false,
+        "mousekey": true,
         "extrakey": true,
         "rgb_matrix": true,
         "pointing_device": true

--- a/keyboards/bastardkb/scylla/keyboard.json
+++ b/keyboards/bastardkb/scylla/keyboard.json
@@ -82,7 +82,7 @@
     },
     "features": {
         "bootmagic": true,
-        "mousekey": false,
+        "mousekey": true,
         "extrakey": true,
         "rgb_matrix": true
     },

--- a/keyboards/bastardkb/skeletyl/keyboard.json
+++ b/keyboards/bastardkb/skeletyl/keyboard.json
@@ -82,7 +82,7 @@
     },
     "features": {
         "bootmagic": true,
-        "mousekey": false,
+        "mousekey": true,
         "extrakey": true,
         "rgb_matrix": true
     },

--- a/keyboards/bastardkb/tbkmini/keyboard.json
+++ b/keyboards/bastardkb/tbkmini/keyboard.json
@@ -82,7 +82,7 @@
     },
     "features": {
         "bootmagic": true,
-        "mousekey": false,
+        "mousekey": true,
         "extrakey": true,
         "rgb_matrix": true
     },


### PR DESCRIPTION
This change enables mouse keys by default on all Charybdis sizes and the Dactyl family on the keyboard level.
Inconsistent click-drag behavior and nonfunctional scroll keys frequently led to user confusion.