### PR TITLE
Remove VIA keymap instructions

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/readme.md
+++ b/keyboards/bastardkb/charybdis/3x5/readme.md
@@ -10,6 +10,8 @@ The Charybdis is available in 4x6 and 3x5 form factor at [bastardkb.com](https:/
 
 A simple QWERTY layout with 4 layers.
 
-### [`via`](keymaps/via)
+### `vendor`
 
-A [Miryoku-inspired](https://github.com/manna-harbour/miryoku), feature-rich, keymap with VIA support.
+The `vendor` keymap is in the `bastardkb/qmk_userspace` repository: https://github.com/Bastardkb/qmk_userspace/
+
+For detailed instructions on how to use them, please see https://docs.bastardkb.com/fw/compile-firmware.html

--- a/keyboards/bastardkb/charybdis/3x6/readme.md
+++ b/keyboards/bastardkb/charybdis/3x6/readme.md
@@ -10,6 +10,8 @@ The Charybdis is available in 4x6, 3x6 and 3x5 form factor at [bastardkb.com](ht
 
 A simple QWERTY layout with 4 layers.
 
-### [`via`](keymaps/via)
+### `vendor`
 
-A [Miryoku-inspired](https://github.com/manna-harbour/miryoku), feature-rich, keymap with VIA support.
+The `vendor` keymap is in the `bastardkb/qmk_userspace` repository: https://github.com/Bastardkb/qmk_userspace/
+
+For detailed instructions on how to use them, please see https://docs.bastardkb.com/fw/compile-firmware.html

--- a/keyboards/bastardkb/charybdis/4x6/readme.md
+++ b/keyboards/bastardkb/charybdis/4x6/readme.md
@@ -2,7 +2,7 @@
 
 An ergonomic keyboard with integrated trackball.
 
-The Charybdis is available in 4x6 and 3x5 form factor at [bastardkb.com](https://bastardkb.com).
+The Charybdis is available in 4x6, 3x6, and 3x5 form factor at [bastardkb.com](https://bastardkb.com).
 
 ## Keymaps
 
@@ -10,6 +10,8 @@ The Charybdis is available in 4x6 and 3x5 form factor at [bastardkb.com](https:/
 
 A simple QWERTY layout with 3 layers.
 
-### [`via`](keymaps/via)
+### `vendor`
 
-Same as the [default](keymaps/default) keymap, but with VIA support.
+The `vendor` keymap is in the `bastardkb/qmk_userspace` repository: https://github.com/Bastardkb/qmk_userspace/
+
+For detailed instructions on how to use them, please see https://docs.bastardkb.com/fw/compile-firmware.html

--- a/keyboards/bastardkb/charybdis/readme.md
+++ b/keyboards/bastardkb/charybdis/readme.md
@@ -18,35 +18,7 @@ Check out the [keyboard build guides](https://docs.bastardkb.com) for the Charyb
 
 ## Building the firmware
 
-The template is:
-
-```shell
-qmk compile -kb bastardkb/charybdis/{LAYOUT} -km {KEYMAP}
-```
-
-See below for populated commands per layout
-
-The `default` keymap is inspired from the original [Dactyl Manuform](../../handwired/dactyl_manuform) layout.
-
-Check out the `via` layout if you're looking for VIA support.
-
-### Charybdis (4x6)
-
-| default                                               | via                                               |
-| ----------------------------------------------------- | ------------------------------------------------- |
-| `qmk compile -kb bastardkb/charybdis/4x6 -km default` | `qmk compile -kb bastardkb/charybdis/4x6 -km via` |
-
-### Charybdis (3x6)
-
-| default                                               | via                                               |
-| ----------------------------------------------------- | ------------------------------------------------- |
-| `qmk compile -kb bastardkb/charybdis/3x6 -km default` | `qmk compile -kb bastardkb/charybdis/3x6 -km via` |
-
-### Charybdis (3x5)
-
-| default                                               | via                                               |
-| ----------------------------------------------------- | ------------------------------------------------- |
-| `qmk compile -kb bastardkb/charybdis/3x5 -km default` | `qmk compile -kb bastardkb/charybdis/3x5 -km via` |
+For instructions on how to build your firmware, please see https://docs.bastardkb.com/fw/compile-firmware.html
 
 ### Legacy hardware
 

--- a/keyboards/bastardkb/dilemma/readme.md
+++ b/keyboards/bastardkb/dilemma/readme.md
@@ -8,14 +8,6 @@ A family of split keyboards with embedded RP2040 controllers, support for Cirque
 
 A DIY version of the 3x5_2 PCB with promicro compatible footprint is also available, but no longer supported. Please see the archived tree at commit [`f0ffdc3b6d`](https://github.com/Bastardkb/bastardkb-qmk/tree/f0ffdc3b6d34b1d0e72474bc2d2296399871d5b9/keyboards/bastardkb/dilemma/).
 
-Make example for this keyboard (after setting up your build environment):
+## Building the firmware
 
-    make bastardkb/dilemma/3x5_3:default
-    make bastardkb/dilemma/4x6_4:default
-
-Flashing example for this keyboard:
-
-    make bastardkb/dilemma/3x5_3:default:flash
-    make bastardkb/dilemma/4x6_4:default:flash
-
-See the [keyboard build instructions](http://docs.bastardkb.com/)
+For instructions on how to build your firmware, please see https://docs.bastardkb.com/fw/compile-firmware.html

--- a/keyboards/bastardkb/scylla/readme.md
+++ b/keyboards/bastardkb/scylla/readme.md
@@ -8,19 +8,7 @@ A modern, low-profile split ergonomic keyboard
 
 ## Building the firmware
 
-The template is:
-
-```shell
-qmk compile -kb bastardkb/scylla -km {KEYMAP}
-```
-
-| default                                             |
-| --------------------------------------------------- |
-| `qmk compile -kb bastardkb/scylla -km default`      |
-
-See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
-
-See the [keyboard build instructions](https://docs.bastardkb.com)
+For instructions on how to build your firmware, please see https://docs.bastardkb.com/fw/compile-firmware.html
 
 ### Legacy hardware
 

--- a/keyboards/bastardkb/skeletyl/readme.md
+++ b/keyboards/bastardkb/skeletyl/readme.md
@@ -8,21 +8,7 @@ A very small keyboard made for ergonomic enthusiasts.
 
 ## Building the firmware
 
-The template is:
-
-```shell
-qmk compile -kb bastardkb/skeletyl -km {KEYMAP}
-```
-
-| default                                            |
-| -------------------------------------------------- |
-| `qmk compile -kb bastardkb/skeletyl -km default`   |
-
-This keyboard is made to be used with the Miryoku layout, do not use the default keymap.
-
-See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
-
-See the [keyboard build instructions](http://docs.bastardkb.com/)
+For instructions on how to build your firmware, please see https://docs.bastardkb.com/fw/compile-firmware.html
 
 ### Legacy hardware
 

--- a/keyboards/bastardkb/tbkmini/readme.md
+++ b/keyboards/bastardkb/tbkmini/readme.md
@@ -8,19 +8,7 @@ A split, compact ergonomic keyboard.
 
 ## Building the firmware
 
-The template is:
-
-```shell
-qmk compile -kb bastardkb/tbkmini -km {KEYMAP}
-```
-
-| default                                              |
-| ---------------------------------------------------- |
-| `qmk compile -kb bastardkb/tbkmini -km default`      |
-
-See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
-
-See the [keyboard build instructions](http://docs.bastardkb.com/)
+For instructions on how to build your firmware, please see https://docs.bastardkb.com/fw/compile-firmware.html
 
 ### Legacy hardware
 


### PR DESCRIPTION
The VIA keymaps were previously stored in the `BK QMK` repository.

They were later moved to `vendor` keymaps in the `BK QMK Userspace` repository.

This PR removes all VIA-related instructions.