### PR TITLE
charybdis 4x6 - Fix maxtrix to LED indices in thumb cluster

### DIFF
--- a/keyboards/bastardkb/charybdis/4x6/4x6.c
+++ b/keyboards/bastardkb/charybdis/4x6/4x6.c
@@ -54,7 +54,7 @@ led_config_t g_led_config = { {
     {     30,     35,     38,     43,     46,     50 }, // Top row
     {     31,     34,     39,     42,     47,     51 }, // Middle row
     {     32,     33,     40,     41,     48,     52 }, // Bottom row
-    { NO_LED,     53,     55,     54, NO_LED, NO_LED }, // Thumb cluster
+    { NO_LED,     53,     NO_LED, 54, NO_LED,     55 }, // Thumb cluster
 }, {
     /* LED index to physical position. */
     // Left split.


### PR DESCRIPTION
On my own user firmware, I was trying to debug an issue with my indicators code, where the smaller right thumb cluster lights were not matching up, here
https://github.com/devoidfury/qmk_userspace/blob/main/keyboards/bastardkb/charybdis/4x6/keymaps/devoid/rgb_indicators.c#L26-L41
and found that somebody else hit this
https://discord.com/channels/681309835135811648/872183402579767317/1126883296744317061

burkfers' proposed change worked for me so I'd like to upstream it.